### PR TITLE
Lazy file loading, improved auto-cheat, and parser fix

### DIFF
--- a/hol4_mcp/hol_file_parser.py
+++ b/hol4_mcp/hol_file_parser.py
@@ -341,6 +341,13 @@ def parse_theorems(content: str) -> list[TheoremInfo]:
         if not term_match:
             continue  # No Termination block — plain definition, skip
 
+        # Check that no End appears before Termination (otherwise it's a
+        # plain Definition...End block, and the Termination belongs to a
+        # later Definition)
+        first_end = re.search(r'^\s*End\s*$', rest_stripped, re.MULTILINE)
+        if first_end and first_end.start() < term_match.start():
+            continue  # Plain definition — End comes before any Termination
+
         end_match = re.search(r'^\s*End\s*$', rest_stripped[term_match.end():], re.MULTILINE)
         if not end_match:
             continue


### PR DESCRIPTION
- Make file content loading lazy: defer to enter_theorem instead of loading all theorems upfront during init (expensive for large files)
- Save base checkpoint lazily on first enter_theorem call
- Improve _cheat_failed_theorem: drain residual output before cheating, check for success (val name) instead of relying on error detection, show last 500 chars on failure instead of first 200
- Handle TIMEOUT during theorem loading: interrupt HOL and auto-cheat instead of treating as fatal error
- Fix Definition...Termination...End parser: check that End doesn't appear before Termination (otherwise it's a plain Definition...End and the Termination belongs to a later Definition)