### PR TITLE
Resume-goal invalidation: only drop on suspension-source edits; FastMCP. fn

### DIFF
--- a/hol4_mcp/hol_cursor.py
+++ b/hol4_mcp/hol_cursor.py
@@ -823,9 +823,17 @@ class FileProofCursor:
         When content changes at line N, all theorems starting at N or later,
         OR containing line N, have invalid checkpoints/traces.
         Also invalidates for deleted theorems (not in new parse).
+
+        Resume goals have special handling: they're only invalidated when the
+        change affects the main theorem containing the corresponding `suspend`,
+        because re-extraction requires the original suspension to still hold
+        its label (which may already be consumed after the Resume ran).
         """
         current_thm_names = {thm.name for thm in self._theorems}
-        
+
+        # Build name → theorem lookup for fast suspension-source queries
+        name_to_thm = {thm.name: thm for thm in self._theorems}
+
         # Invalidate checkpoints/traces/tc_goals for theorems that no longer exist
         for name in list(self._checkpoints.keys()):
             if name not in current_thm_names:
@@ -839,7 +847,7 @@ class FileProofCursor:
         for name in list(self._resume_goals.keys()):
             if name not in current_thm_names:
                 del self._resume_goals[name]
-        
+
         # Invalidate checkpoints/traces/tc_goals/resume_goals for theorems at or after change point
         for thm in self._theorems:
             if thm.proof_end_line >= start_line:
@@ -848,7 +856,37 @@ class FileProofCursor:
                     del self._proof_traces[thm.name]
                 if thm.name in self._tc_goals:
                     del self._tc_goals[thm.name]
-                if thm.name in self._resume_goals:
+                # Resume goals: invalidate only when change affects the
+                # extraction context (main theorem or a nested suspending
+                # Resume earlier in the chain). Once a Resume's label has
+                # been consumed by its own run, re-extraction is impossible
+                # without session rollback.
+                if thm.kind == "Resume" and thm.name in self._resume_goals:
+                    source_thm = name_to_thm.get(thm.suspension_name) if thm.suspension_name else None
+                    # The main `suspend "X"` for a Resume block lives either
+                    # in the original Theorem or in an earlier Resume of the
+                    # same theorem chain. Walk the chain to see if any
+                    # ancestor's body was touched.
+                    affected = False
+                    if source_thm and start_line <= source_thm.proof_end_line:
+                        affected = True
+                    if not affected:
+                        # Check earlier Resume blocks on the same suspension:
+                        # their bodies can contain further `suspend` calls
+                        # whose labels this Resume depends on.
+                        for other in self._theorems:
+                            if other is thm:
+                                break
+                            if (other.kind == "Resume"
+                                    and other.suspension_name == thm.suspension_name
+                                    and other.start_line < thm.start_line
+                                    and start_line <= other.proof_end_line):
+                                affected = True
+                                break
+                    if affected:
+                        del self._resume_goals[thm.name]
+                elif thm.name in self._resume_goals:
+                    # Non-Resume (shouldn't happen, but keep safe): drop
                     del self._resume_goals[thm.name]
 
     async def init(self) -> dict:

--- a/hol4_mcp/hol_mcp_server.py
+++ b/hol4_mcp/hol_mcp_server.py
@@ -482,8 +482,10 @@ async def hol_restart(session: str = "default") -> str:
 
     workdir = entry.workdir
     env = entry.env  # Preserve env through restart
-    await hol_stop(session)
-    return await hol_start(workdir=str(workdir), name=session, env=env)
+    # hol_stop/hol_start are @mcp.tool()-wrapped FunctionTool objects in
+    # FastMCP 3.x — the raw coroutine is exposed via `.fn`.
+    await hol_stop.fn(session)
+    return await hol_start.fn(workdir=str(workdir), name=session, env=env)
 
 
 @mcp.tool()
@@ -512,7 +514,7 @@ async def hol_setenv(env: dict, session: str = "default") -> str:
 
     # Auto-restart to apply new env to running process
     if entry.session.is_running:
-        restart_result = await hol_restart(session)
+        restart_result = await hol_restart.fn(session)
         return f"Environment updated and session restarted: {env}\n{restart_result}"
 
     return f"Environment updated for session '{session}': {env}"
@@ -816,7 +818,7 @@ async def _init_file_cursor(
     if s and s.is_running:
         # Check if workdir differs - need to restart
         if entry and entry.workdir != target_workdir:
-            await hol_stop(session)
+            await hol_stop.fn(session)
             s = None
         # Check if file content changed - session has stale definitions
         elif entry and entry.cursor:
@@ -828,13 +830,13 @@ async def _init_file_cursor(
                 new_hash = hashlib.sha256(new_content.encode()).hexdigest()
                 if old_hash and new_hash != old_hash:
                     # File changed - restart session to clear stale definitions
-                    await hol_stop(session)
+                    await hol_stop.fn(session)
                     s = None
 
     if not s or not s.is_running:
         # Preserve per-session HOL env (e.g., VFMDIR) across auto-restarts.
         start_env = entry.env if entry else None
-        start_result = await hol_start(workdir=str(target_workdir), name=session, env=start_env)
+        start_result = await hol_start.fn(workdir=str(target_workdir), name=session, env=start_env)
         if start_result.startswith("ERROR"):
             return start_result
         s = await _get_session(session)


### PR DESCRIPTION
Two fixes:

1. FileProofCursor._invalidate_after_line (hol_cursor.py): only drop a Resume block's cached goal when the edit affects the source that issued its `suspend` label — i.e. the main theorem or an earlier Resume in the same chain whose body contained the label-producing `suspend`. Dropping on any touch past the Resume's own start line was too aggressive: once a Resume runs, its label is consumed, so re-extraction fails with "No such label in theorem: <label>" for Resumes whose extraction context is untouched.

2. Internal tool calls use .fn (hol_mcp_server.py): hol_stop, hol_start, hol_restart are @mcp.tool()-wrapped FunctionTool objects in FastMCP 3.x, so the raw coroutine must be reached via .fn when called from inside the server.