### PR TITLE
Fix _step_plan drift: reparse when _step_plan_hash != _content_hash

### DIFF
--- a/hol4_mcp/hol_cursor.py
+++ b/hol4_mcp/hol_cursor.py
@@ -349,6 +349,12 @@ class FileProofCursor:
         # Active theorem state
         self._active_theorem: str | None = None
         self._step_plan: list[StepPlan] = []  # Step boundaries aligned with e() commands
+        # Hash of self._content at which _step_plan was computed. If it diverges
+        # from self._content_hash, _step_plan is stale — _compute_target must
+        # reparse. Prevents stale-plan drift when _reparse_if_changed runs via
+        # a non-state_at caller (e.g. cursor.status for hol_sessions) and
+        # updates _content_hash without re-running goalfrag_step_plan_json.
+        self._step_plan_hash: str = ""
         self._pos = SessionPosition()  # Where HOL session is (updated atomically by state_at)
 
         # What's been loaded into HOL
@@ -528,6 +534,7 @@ class FileProofCursor:
         self._pos = SessionPosition()
         self._active_theorem = None
         self._step_plan = []
+        self._step_plan_hash = ""
         self._needs_session_reinit = False
 
         # Re-run full initialization to rebuild deps/context/checkpoints
@@ -1411,6 +1418,7 @@ class FileProofCursor:
                 return {"error": f"Failed to parse step plan: {e}"}
         else:
             self._step_plan = []
+        self._step_plan_hash = self._content_hash
 
         self._active_theorem = name
         self._pos = SessionPosition()  # Reset position for new theorem
@@ -1785,8 +1793,13 @@ class FileProofCursor:
         On file change, invalidates checkpoints, reparses step plan, and computes
         incremental diff for optimization. Returns _TargetInfo or error StateAtResult.
         """
+        # Reparse step plan if content changed since state_at last ran (changed=True)
+        # OR if the step plan is stale relative to current content (drift — can happen
+        # when a non-state_at caller like cursor.status ran _reparse_if_changed and
+        # advanced _content_hash without updating _step_plan).
+        needs_reparse = changed or self._step_plan_hash != self._content_hash
         incremental_update = None
-        if changed:
+        if needs_reparse:
             incremental_update = await self._reparse_steps_on_edit(thm)
             if isinstance(incremental_update, StateAtResult):
                 return incremental_update
@@ -1873,6 +1886,7 @@ class FileProofCursor:
                 )
         else:
             self._step_plan = []
+        self._step_plan_hash = self._content_hash
 
         # Commands that match produce identical proof state.
         # Keep the common prefix, redo from first divergence.


### PR DESCRIPTION
## Summary

`_reparse_if_changed()` updates `_content`, `_content_hash`, `_theorems`, and `_line_starts` inline, but the step plan is only rebuilt inside `_reparse_steps_on_edit()` — which runs only when `state_at()` observes `changed=True`.

Any _other_ caller that reaches `_reparse_if_changed()` — e.g. `cursor.status` invoked by `hol_sessions` — can advance `_content_hash` past an edit without touching `_step_plan`. A subsequent `state_at()` then sees `_reparse_if_changed()` report `changed=False`, `_compute_target()` skips the reparse, and `_step_plan` is left as the OLD plan. That in turn drives `total_tactics`, the target `tactic_idx`, the "Failing tactic" text in `PROOF BROKEN`, and the commands replayed — all from the pre-edit file.

## How I hit this

Editing a real proof, then calling `hol_state_at` after the session had been touched by unrelated MCP activity: got a `PROOF BROKEN` report whose "Failing tactic" quoted tactic text that no longer existed in the file, with line numbers resolved via the _new_ `_line_starts`. After much head-scratching, traced to this drift.

Minimal repro (no HOL session needed — stubs the HOLSession, only exercises cursor state): content_hash advances via `cursor.status`; a later `_reparse_if_changed()` returns `changed=False`; `_step_plan` is still the OLD plan.

## Fix

Track `_step_plan_hash` alongside `_step_plan`. Stamp it at every assignment site:

- `FileProofCursor.__init__` → `""`
- `_reinitialize_session_if_needed` → `""` (alongside the other resets)
- `enter_theorem` → `self._content_hash` after (re)parsing
- `_reparse_steps_on_edit` → `self._content_hash` after (re)parsing

In `_compute_target`, trigger the reparse via:

```python
needs_reparse = changed or self._step_plan_hash != self._content_hash
```

`_reparse_steps_on_edit` refreshes both fields atomically so the invariant holds.

## Test plan

- [x] Deterministic stale-state trace: simulates the drift (edit + `cursor.status` access). Before fix, `_step_plan` stays OLD. After fix, drift is detectable in `_compute_target`.
- [x] End-to-end: init + navigate + edit + `hol_sessions` + `hol_state_at` on a fresh session (fastmcp 3.2.4). Before fix, output contained stale OLD tactic text. After fix, it doesn't.

🤖 Generated with [Claude Code](https://claude.com/claude-code)