### PR TITLE
Drop holmake progress notifications to fix stdio disconnect

### DIFF
--- a/hol4_mcp/hol_mcp_server.py
+++ b/hol4_mcp/hol_mcp_server.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from fastmcp import FastMCP, Context
+from fastmcp import FastMCP
 
 from .hol_session import HOLSession, HOLDIR
 from .hol_cursor import FileProofCursor
@@ -625,7 +625,7 @@ _PROGRESS_INTERVAL = 10  # seconds
 
 
 @mcp.tool()
-async def holmake(workdir: str, target: str = None, env: dict = None, log_limit: int = 1024, timeout: int = 90, heap_size: int = 12288, jobs: int = None, ctx: Context = None) -> str:
+async def holmake(workdir: str, target: str = None, env: dict = None, log_limit: int = 1024, timeout: int = 90, heap_size: int = 12288, jobs: int = None) -> str:
     """Run Holmake --qof in directory.
 
     Args:
@@ -638,9 +638,6 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
         jobs: Max parallel jobs (-j flag). Default from HOL4_MCP_HOLMAKE_JOBS env var, or 1.
 
     Returns: Holmake output (stdout + stderr). On failure, includes recent build logs.
-
-    Note: For builds > 60s, progress notifications are sent every 10s to prevent
-    MCP client timeout. Configure tool_timeout_sec in ~/.codex/config.toml if needed.
     """
     # Validate limits
     timeout = max(1, min(timeout, 1800))
@@ -691,7 +688,9 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
             start_new_session=True,
         )
 
-        # Poll with progress reporting to prevent MCP client timeout
+        # Poll stdout. Progress notifications were removed: a notification
+        # in flight when the response is emitted races on the wire and the
+        # client tears down the stdio transport on the late progressToken.
         start_time = time.time()
         stdout_chunks = []
         timed_out = False
@@ -702,18 +701,6 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
                 timed_out = True
                 break
 
-            # Report progress to reset client timeout (MCP resetTimeoutOnProgress)
-            if ctx:
-                try:
-                    await ctx.report_progress(
-                        progress=elapsed,
-                        total=float(timeout),
-                        message=f"Building... {int(elapsed)}s / {timeout}s"
-                    )
-                except Exception:
-                    pass  # Don't fail build if progress reporting fails
-
-            # Wait for output or timeout after interval
             try:
                 chunk = await asyncio.wait_for(
                     proc.stdout.read(4096),


### PR DESCRIPTION
The holmake tool fired ctx.report_progress every iteration of its stdout poll. When the holmake subprocess exited, the loop's last notification could still be in flight on stdio while the tool response was already serialized for emission. The MCP client received the late progress notification AFTER the response had retired the request's progressToken, raising "Received a progress notification for an unknown token" and tearing down the stdio transport.

Reproducer (from a real session log):

    Tool 'holmake' still running (150s elapsed)
    STDIO connection dropped after 5908s uptime
    Connection error: Received a progress notification for an
      unknown token: progressToken=149 progress=173.10 total=600
    Closing transport (stdio transport error: Error)
    Tool 'holmake' completed successfully in 2m 53s

(All four messages within the same millisecond.)

Remove the in-loop ctx.report_progress block and the now-unused Context parameter / import. The polling loop still tracks elapsed time for the tool-level timeout; long calls without progress remain visible to the user via the client's own "still running" debug log.

This fix only addresses the progress-notification race. A separate, more frequent disconnect path — "Received a response for an unknown message ID: ... Request cancelled" — fires when a tool call is cancelled mid-flight and the server still emits the JSON-RPC error reply for the retired id; that bug lives in the fastmcp framework layer and is not addressed here.