### PR TITLE
holmake: drop progress notifications (stdio disconnect race)

### DIFF
--- a/hol4_mcp/hol_mcp_server.py
+++ b/hol4_mcp/hol_mcp_server.py
@@ -19,7 +19,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Optional
 
-from fastmcp import FastMCP, Context
+from fastmcp import FastMCP
 
 from .hol_session import HOLSession, HOLDIR
 from .hol_cursor import FileProofCursor
@@ -625,7 +625,7 @@ _PROGRESS_INTERVAL = 10  # seconds
 
 
 @mcp.tool()
-async def holmake(workdir: str, target: str = None, env: dict = None, log_limit: int = 1024, timeout: int = 90, heap_size: int = 12288, jobs: int = None, ctx: Context = None) -> str:
+async def holmake(workdir: str, target: str = None, env: dict = None, log_limit: int = 1024, timeout: int = 90, heap_size: int = 12288, jobs: int = None) -> str:
     """Run Holmake --qof in directory.
 
     Args:
@@ -638,9 +638,6 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
         jobs: Max parallel jobs (-j flag). Default from HOL4_MCP_HOLMAKE_JOBS env var, or 1.
 
     Returns: Holmake output (stdout + stderr). On failure, includes recent build logs.
-
-    Note: For builds > 60s, progress notifications are sent every 10s to prevent
-    MCP client timeout. Configure tool_timeout_sec in ~/.codex/config.toml if needed.
     """
     # Validate limits
     timeout = max(1, min(timeout, 1800))
@@ -691,7 +688,9 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
             start_new_session=True,
         )
 
-        # Poll with progress reporting to prevent MCP client timeout
+        # Poll stdout. Progress notifications were removed: a notification
+        # in flight when the response is emitted races on the wire and the
+        # client tears down the stdio transport on the late progressToken.
         start_time = time.time()
         stdout_chunks = []
         timed_out = False
@@ -702,18 +701,6 @@ async def holmake(workdir: str, target: str = None, env: dict = None, log_limit:
                 timed_out = True
                 break
 
-            # Report progress to reset client timeout (MCP resetTimeoutOnProgress)
-            if ctx:
-                try:
-                    await ctx.report_progress(
-                        progress=elapsed,
-                        total=float(timeout),
-                        message=f"Building... {int(elapsed)}s / {timeout}s"
-                    )
-                except Exception:
-                    pass  # Don't fail build if progress reporting fails
-
-            # Wait for output or timeout after interval
             try:
                 chunk = await asyncio.wait_for(
                     proc.stdout.read(4096),


### PR DESCRIPTION
## Bug

A long \`holmake\` call can take down the MCP stdio transport, removing every \`hol4__*\` tool from the client mid-session. From a real session log (\`mcp-logs-hol4/2026-04-26T00-25-12-253Z.jsonl\`):

\`\`\`
Tool 'holmake' still running (150s elapsed)              @ 02:03:18
STDIO connection dropped after 5908s uptime              @ 02:03:41
Connection error: Received a progress notification for
  an unknown token: progressToken=149, progress=173.10,
  total=600, message=\"Building... 173s / 600s\"           @ 02:03:41
Closing transport (stdio transport error: Error)         @ 02:03:41
Tool 'holmake' completed successfully in 2m 53s          @ 02:03:41
\`\`\`

All four messages within the same millisecond. The same disconnect signature recurred on \`2026-04-24T16-25-48-012Z.jsonl\` (\`progressToken=94\`, \`progress=315\`).

### Race

\`holmake\` polls the subprocess stdout in a loop and fires \`ctx.report_progress(...)\` on every iteration. When the subprocess exits, the very last progress notification can be in flight on stdio while the tool response is already being serialized. The client receives the response, retires the request's progressToken, and a moment later sees a notification referencing that retired token — which the MCP client treats as a fatal stdio error and closes the connection.

## Fix

Remove the \`ctx.report_progress\` block from \`holmake\`'s polling loop, plus the now-unused \`Context\` parameter and import. The polling loop still tracks elapsed time for the tool-level timeout; the loop body is otherwise unchanged.

\`\`\`
 hol4_mcp/hol_mcp_server.py | 23 +++++------------------
 1 file changed, 5 insertions(+), 18 deletions(-)
\`\`\`

The original justification for the progress notification was \"reset MCP client timeout (resetTimeoutOnProgress)\". In practice Claude Code's stdio MCP client already emits its own \`Tool 'holmake' still running (Ns elapsed)\` debug line every 30s without server-side progress, and \`holmake\`'s tool-level timeout (max 1800s) is large enough that no progress is needed for the client to keep the call open.

## Marked as draft — other directions are possible

This is a minimal, surgical fix. Reasonable alternatives:

1. **Keep progress notifications, fix the race.** Suppress the notification in the iteration that detects EOF, or sequence the final notification before the response (\`await ctx.report_progress(...); await proc.wait(); return ...\`). More invasive and still depends on fastmcp ordering its stdio writes correctly.
2. **Pin / patch fastmcp.** The wider symptom is fastmcp emitting protocol messages that the MCP client treats as stray. The same session logs also show a related disconnect signature \`Received a response for an unknown message ID: ... Request cancelled\`, fired when a tool is cancelled mid-flight; that path is independent of \`holmake\` and lives in fastmcp's response layer. A coordinated upstream fix would address both.
3. **Replace stdio progress with periodic logs.** If progress is genuinely useful for very long builds, write it to a side log file or an in-server ring buffer that's read out via a separate \`hol_log\` query, not over the JSON-RPC notification channel.

Happy to take this in a different direction if any of the above is preferred. Posting the minimal fix now because the disconnect is reproducible and disruptive enough to want a quick mitigation.

## Reproducer

Any holmake invocation that takes > ~30s and ends with the subprocess exiting will eventually trip the race; making it reliable requires multiple sequential calls. With this patch applied, the same session no longer disconnects.

🤖 Generated with [Claude Code](https://claude.com/claude-code)