### PR TITLE
Preserve SELECT_GOAL_LT prefix when `>~ [pat] >- (body)` body is compound

### DIFF
--- a/hol4_mcp/sml_helpers/tactic_prefix.sml
+++ b/hol4_mcp/sml_helpers/tactic_prefix.sml
@@ -272,16 +272,29 @@ fun merge_select_steps [] acc = rev acc
             | mkSelectPrefix (p :: ps) = "Q.SELECT_GOAL_LT " ^ p ^ " >>~ Q.SELECT_GOALS_LT " ^
                 String.concatWith " >>~ Q.SELECT_GOALS_LT " ps
           val selectPrefix = mkSelectPrefix sels
-          (* Try to consume the following bracket: open expand close *)
+          (* Try to consume the following bracket: open (expand)+ close.
+             The body may be a single expand (e.g. >- simp[]) or a compound
+             of expands joined by >> (e.g. >- (simp[] >> fs[])).
+             Bail (NONE) for nested brackets or unexpected fragment kinds —
+             those would need full source reconstruction. *)
+          fun isOpenArm "open_then1" = true
+            | isOpenArm "open_first" = true
+            | isOpenArm _ = false
+          fun walkArm [] _ _ = NONE
+            | walkArm ((endP, "close", _) :: rest') texts lastEnd =
+                (case rev texts of
+                   [] => NONE
+                 | [single] => SOME (selectPrefix ^ " >- " ^ single, lastEnd, rest')
+                 | many => SOME (
+                     selectPrefix ^ " >- (" ^
+                     String.concatWith " >> " many ^ ")",
+                     lastEnd, rest'))
+            | walkArm ((endP, "expand", t) :: rest') texts _ =
+                walkArm rest' (t :: texts) endP
+            | walkArm _ _ _ = NONE  (* nested open/mid: bail *)
           fun tryConsumeBracket [] = NONE
-            | tryConsumeBracket ((_, "open", "open_then1") ::
-                                (tacEnd, "expand", tacText) ::
-                                (_, "close", _) :: rest') =
-                SOME (selectPrefix ^ " >- " ^ tacText, tacEnd, rest')
-            | tryConsumeBracket ((_, "open", "open_first") ::
-                                (tacEnd, "expand", tacText) ::
-                                (_, "close", _) :: rest') =
-                SOME (selectPrefix ^ " >- " ^ tacText, tacEnd, rest')
+            | tryConsumeBracket ((_, "open", openName) :: rest') =
+                if isOpenArm openName then walkArm rest' [] 0 else NONE
             | tryConsumeBracket _ = NONE
         in
           case tryConsumeBracket afterSels of

--- a/tests/test_tactic_prefix.py
+++ b/tests/test_tactic_prefix.py
@@ -420,6 +420,53 @@ class TestGoalfragSelectGoalDecomposition:
                 assert not step.text.startswith("[`"), \
                     f"Bare pattern expand step found: {step.text}"
 
+    async def test_select_goal_compound_body_then(self, hol_session):
+        """>~[pat] >- (a >> b): compound body must be merged, not silently dropped.
+
+        Regression: previously the SELECT_GOAL_LT prefix was dropped when the
+        `>-` body had multiple tactics joined by `>>` (the bracket pattern
+        match in tryConsumeBracket was open+single_expand+close). With the
+        prefix dropped, the `>~` selector never executed and `>-` ran on the
+        un-reordered goal stack, picking the wrong goal."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (simp[] >> fs[])")
+        # Must produce: expand(Cases_on), expand_list(Q.SELECT_GOAL_LT [`Foo`] >- (simp[] >> fs[]))
+        assert len(result) == 2, f"Expected 2 steps, got {len(result)}: {[(s.kind, s.text) for s in result]}"
+        assert result[0].kind == "expand"
+        assert result[1].kind == "expand_list", \
+            f"Compound body should yield expand_list step, got kind={result[1].kind} text={result[1].text!r}"
+        assert "Q.SELECT_GOAL_LT" in result[1].text
+        assert "`Foo`" in result[1].text
+        assert "simp[]" in result[1].text
+        assert "fs[]" in result[1].text
+
+    async def test_select_goal_compound_body_three_then(self, hol_session):
+        """>~[pat] >- (a >> b >> c): three-tactic compound body."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (a >> b >> c)")
+        assert len(result) == 2
+        assert result[1].kind == "expand_list"
+        assert "Q.SELECT_GOAL_LT" in result[1].text
+        # All three sub-tactics must be present
+        for tac in ("a", "b", "c"):
+            assert tac in result[1].text
+
+    async def test_select_goal_compound_body_associativity(self, hol_session):
+        """Compound body must parenthesize so `>-` doesn't bind only to first sub-tactic.
+
+        `Q.SELECT_GOAL_LT [pat] >- a >> b` parses as
+          `(Q.SELECT_GOAL_LT [pat] >- a) >> b`
+        which would run `b` on goals OUTSIDE the >- arm. The body must be
+        wrapped in parens so the entire compound is the arm body."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (simp[] >> fs[])")
+        # The combined text must keep simp[] >> fs[] grouped (parens, or some
+        # equivalent that prevents `>-` from binding only to simp[]).
+        text = result[1].text
+        # Find the position of `>-` and check what follows is parenthesized
+        dash_idx = text.find(">-")
+        assert dash_idx >= 0
+        body = text[dash_idx + 2:].lstrip()
+        assert body.startswith("("), \
+            f"Compound body must be parenthesized; got {body!r}"
+
 
 # =============================================================================
 # Resume goal extraction


### PR DESCRIPTION
## Summary

`merge_select_steps` in `tactic_prefix.sml` only matched bracket bodies of shape `open + single_expand + close`. When the body of a `>~ [pat] >- (...)` arm contained multiple sub-tactics joined by `>>` (multiple expand fragments inside the bracket), `tryConsumeBracket` returned `NONE` and the select step was **silently dropped**.

Runtime effect: the `>~ [pat]` selector never reordered the goal stack, the bare `>-` then ran on the un-reordered first goal, and the `>~` arm body was applied to the wrong subgoal — leading to silently-wrong proofs in `hol_check_proof` (proofs that pass under interactive `e()` because the chain is parsed and run as one tactic, but fail step-by-step).

## Repro

In the file under test:
```
Theorem t:
  ∀p. P p
Proof
  ho_match_mp_tac P_ind >> rw[P_def]
  >~ [`Loop names body exit_names`] >- (fs[every_var_def, ...] >> metis_tac[...])
  ...
QED
```

Pre-fix step plan: `expand(rw[...])`, **bare** `>-`, `expand(fs[...])`, `expand(metis_tac[...])`, `close` — `Q.SELECT_GOAL_LT` is missing. The wrong goal is extracted by `>-`.

Post-fix step plan: `expand(rw[...])`, `expand_list(Q.SELECT_GOAL_LT [\`Loop ...\`] >- (fs[...] >> metis_tac[...]))` — selector preserved.

## Fix

Replace the pinned 3-fragment match with a small walker over the bracket contents that collects every expand text up to the matching close. Multi-expand bodies are joined with `>>` and **parenthesized** so `>-` binds the entire body (otherwise `Q.SELECT_GOAL_LT [pat] >- a >> b` parses as `(Q.SELECT_GOAL_LT [pat] >- a) >> b` and `b` runs outside the arm). Single-expand bodies still emit the original unparenthesized form, so existing tests are unaffected.

Nested opens/mids inside the bracket still bail to `NONE` — reconstructing those cleanly would need source-text slicing, which this change deliberately doesn't tackle.

## Test plan

- [x] New: `test_select_goal_compound_body_then` — `>~[pat] >- (a >> b)` produces a single `expand_list` with both sub-tactics.
- [x] New: `test_select_goal_compound_body_three_then` — three-tactic compound body.
- [x] New: `test_select_goal_compound_body_associativity` — combined text parenthesizes the body so `>-` doesn't bind only to the first sub-tactic.
- [x] Existing 5 single-body `>~`/`>>~` tests in `TestGoalfragSelectGoalDecomposition` still pass.
- [x] Full `tests/test_tactic_prefix.py` passes (47 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)