### PR TITLE
Fix `P` by tac decomposition for multi-goal contexts

### DIFF
--- a/hol4_mcp/sml_helpers/tactic_prefix.sml
+++ b/hol4_mcp/sml_helpers/tactic_prefix.sml
@@ -294,12 +294,89 @@ fun merge_select_steps [] acc = rev acc
       else
         merge_select_steps rest ((endP, kind, patText) :: acc)
 
+(* merge_by_steps: Post-process step list to merge a Subgoal atom (`P`) and
+   its following >- bracket back into a single atomic `P` by tac step.
+
+   WHY: `P` by tac is parsed by HOL4 as a single tactic equivalent to
+   `subgoal P >- tac`. When applied via THEN-distribution (\\ / >>) over a
+   multi-goal stack, HOL4 runs this tactic atomically per goal: each goal
+   independently gets P proven (by tac) and added as a hypothesis. Per goal:
+   1 in, 1 out.
+
+   The naive decomposition `expand (sg P), open_then1, expand tac, close_paren`
+   does NOT match this semantics. `expand (sg P)` distributes per-goal
+   (correctly producing 2N goals: [P_1, cont_1, ..., P_N, cont_N]), but
+   `open_then1` is a goalstate-level fragment tactic that always focuses on
+   the FIRST top-level goal. So only P_1 gets discharged; P_2..P_N remain
+   open as subgoals. Subsequent tactics applied via THEN do not generally
+   close those — they were meant to operate on the cont_i, not on the P_i.
+
+   This is exactly the bug that occurs when proofs use the common idiom
+
+       Cases_on `q` \\ ... \\ `tttt = ttt` by tac \\ fs[option_le_max]
+
+   after a multi-goal split. In real HOL4 (Holmake), the proof passes; in
+   the MCP's decomposed replay, N-1 sg-subgoals remain unproven and the
+   theorem looks INCOMPLETE.
+
+   Fix: detect the [Subgoal `P`, open_then1, expand+, close_paren] sequence
+   and merge it into a single atomic step `P by tac` (or `P by (t1 >> t2)`
+   for a compound body). The merged step is run via goalFrag.expand and
+   distributes correctly per-goal — matching Holmake.
+
+   Bails (no merge) on nested open/mid inside the body — those would need
+   full source reconstruction to preserve. The unmerged case keeps the old
+   behaviour, which is correct in single-goal contexts (top-level `P` by tac
+   without an upstream multi-goal-producing tactic in the same THEN chain). *)
+fun isSubgoalText t =
+      String.size t >= 4 andalso
+      String.substring (t, 0, 3) = "sg " andalso
+      String.sub (t, 3) = #"`"
+
+fun stripSgPrefix t = String.substring (t, 3, String.size t - 3)
+
+fun merge_by_steps [] acc = rev acc
+  | merge_by_steps ((endP, "expand", subgoalText) :: rest) acc =
+      if isSubgoalText subgoalText then
+        let
+          val patText = stripSgPrefix subgoalText
+          (* Walk a single >- arm: expand+, close. Bail on nested opens. *)
+          fun walkArm [] _ _ = NONE
+            | walkArm ((closeEnd, "close", _) :: rest') texts _ =
+                (case rev texts of
+                   [] => NONE
+                 | [single] => SOME (patText ^ " by " ^ single, closeEnd, rest')
+                 | many => SOME (patText ^ " by (" ^
+                                 String.concatWith " >> " many ^ ")",
+                                 closeEnd, rest'))
+            | walkArm ((endP', "expand", t) :: rest') texts _ =
+                walkArm rest' (t :: texts) endP'
+            | walkArm _ _ _ = NONE
+          fun tryConsume ((_, "open", "open_then1") :: rest') =
+                walkArm rest' [] 0
+            | tryConsume _ = NONE
+        in
+          case tryConsume rest of
+            SOME (combinedText, closeEnd, rest') =>
+              merge_by_steps rest' ((closeEnd, "expand", combinedText) :: acc)
+          | NONE =>
+              merge_by_steps rest ((endP, "expand", subgoalText) :: acc)
+        end
+      else
+        merge_by_steps rest ((endP, "expand", subgoalText) :: acc)
+  | merge_by_steps (step :: rest) acc =
+      merge_by_steps rest (step :: acc)
+
 (* goalfrag_step_plan: Generate fragment steps from linearize fragments.
    Returns (end_offset, type, text) triples for every navigable position.
    Every fragment boundary is a step boundary -- no heuristics needed.
    LSelectGoal/LSelectGroups fragments are merged with their following
    bracket into a single expand_list step (SELECT_GOAL_LT requires
-   goalFrag.expand_list, not goalFrag.expand). *)
+   goalFrag.expand_list, not goalFrag.expand).
+   Subgoal atoms (`P`) are merged with their following >- arm into a single
+   atomic `P` by tac step (preserves HOL4's per-goal distribution semantics
+   when the by-pattern is in a THEN-distributed chain after a multi-goal-
+   producing tactic — see merge_by_steps). *)
 fun goalfrag_step_plan proofBody =
   let
     val tree = parseTacticBlockFromString proofBody
@@ -329,8 +406,9 @@ fun goalfrag_step_plan proofBody =
             else assignEnds rest lastAtomEnd acc
           end
     val rawSteps = assignEnds reexpanded 0 []
+    val afterSelect = merge_select_steps rawSteps []
   in
-    merge_select_steps rawSteps []
+    merge_by_steps afterSelect []
   end
 
 fun goalfrag_step_plan_json proofBody =

--- a/tests/test_tactic_prefix.py
+++ b/tests/test_tactic_prefix.py
@@ -261,39 +261,60 @@ class TestThenLTReexpand:
         assert result[4].kind == "expand" and result[4].text == "fs[]"
 
     async def test_by_in_then_chain(self, hol_session):
-        """`by` inside >> chain decomposes: `Q` gets sg prefix, tactic base stays as-is."""
+        """`P` by tac inside >> chain merges into a SINGLE atomic step.
+
+        Why not decomposed: the naive [sg `P`, open_then1, tac, close_paren]
+        decomposition is INCORRECT under THEN-distribution over multiple
+        goals, because open_then1 only focuses the first global goal,
+        leaving N-1 sg-subgoals open. HOL4's actual `P` by tac is atomic
+        and distributes per-goal correctly. See test_by_distributes_over_*
+        below for the end-to-end regression."""
         result = await call_step_plan(hol_session, r"strip_tac >> `Q` by simp[] >> fs[]")
-        # strip_tac, sg `Q`, open_then1, simp[], close_paren, fs[]
-        assert len(result) == 6, f"Expected 6 steps, got {len(result)}: {[s.text for s in result]}"
+        # strip_tac, `Q` by simp[], fs[]
+        assert len(result) == 3, f"Expected 3 steps, got {len(result)}: {[s.text for s in result]}"
         assert result[0].kind == "expand" and result[0].text == "strip_tac"
-        assert result[1].kind == "expand" and result[1].text.startswith("sg")
-        assert result[2].kind == "open" and result[2].text == "open_then1"
-        assert result[3].kind == "expand" and "simp" in result[3].text
-        assert result[4].kind == "close" and result[4].text == "close_paren"
-        assert result[5].kind == "expand" and result[5].text == "fs[]"
+        assert result[1].kind == "expand" and result[1].text == "`Q` by simp[]"
+        assert result[2].kind == "expand" and result[2].text == "fs[]"
 
     async def test_by_tactic_base_no_sg_prefix(self, hol_session):
-        """`by` with tactic base (not term quotation) keeps base text unchanged."""
+        """`by` with tactic base (not term quotation) keeps base text unchanged.
+
+        Tactic-base `by` is not a Subgoal-from-term-quote pattern, so it does
+        not get the sg-prefix and does NOT trigger merge_by_steps. It keeps
+        the old decomposition (which is rare and benign in practice)."""
         result = await call_step_plan(hol_session, "strip_tac by simp[]")
         # strip_tac (not "sg strip_tac"), open_then1, simp[], close_paren
         assert len(result) == 4, f"Expected 4 steps, got {len(result)}: {[s.text for s in result]}"
         assert result[0].text == "strip_tac", f"Tactic base should not get sg: {result[0].text}"
 
-    async def test_sg_in_then_chain_decomposes(self, hol_session):
-        """`sg >-` inside >> chain decomposes."""
+    async def test_sg_in_then_chain_merges(self, hol_session):
+        """Explicit `sg `Q` >- tac` is semantically identical to ``Q` by tac`
+        and is merged the same way."""
         result = await call_step_plan(hol_session, r"strip_tac >> sg `Q` >- simp[] >> fs[]")
-        # strip_tac, sg `Q`, open_then1, simp[], close_paren, fs[]
-        assert len(result) == 6, f"Expected 6 steps, got {len(result)}: {[s.text for s in result]}"
-        assert result[1].kind == "expand" and "sg" in result[1].text.lower()
-        assert result[2].kind == "open"
+        # strip_tac, `Q` by simp[], fs[]
+        assert len(result) == 3, f"Expected 3 steps, got {len(result)}: {[s.text for s in result]}"
+        assert result[1].kind == "expand"
+        assert "by" in result[1].text and "`Q`" in result[1].text
 
-    async def test_by_term_base_gets_sg_prefix(self, hol_session):
-        """Standalone `by` with term quotation base gets sg prefix."""
+    async def test_by_term_base_merges(self, hol_session):
+        """Standalone `P` by tac (no enclosing chain) merges into one step."""
         result = await call_step_plan(hol_session, r"`Q` by simp[]")
-        # sg `Q`, open_then1, simp[], close_paren
-        assert len(result) == 4, f"Expected 4 steps, got {len(result)}: {[s.text for s in result]}"
-        assert result[0].text.startswith("sg"), f"Term base should get sg: {result[0].text}"
-        assert result[1].kind == "open"
+        # `Q` by simp[]
+        assert len(result) == 1, f"Expected 1 step, got {len(result)}: {[s.text for s in result]}"
+        assert result[0].kind == "expand"
+        assert result[0].text == "`Q` by simp[]"
+
+    async def test_by_compound_body_merges(self, hol_session):
+        """`P` by (t1 >> t2): compound body merges with parens to keep
+        binding correct (so >- doesn't bind only to t1)."""
+        result = await call_step_plan(hol_session, r"`Q` by (simp[] >> fs[])")
+        assert len(result) == 1, f"Expected 1 step, got {len(result)}: {[s.text for s in result]}"
+        text = result[0].text
+        assert "`Q`" in text and "by" in text
+        # body grouped via parens
+        assert "(simp[] >> fs[])" in text or "(simp[]) >> (fs[])" in text or \
+               text.endswith("by (simp[] >> fs[])"), \
+            f"Compound body must be parenthesized after `by`: {text!r}"
 
     async def test_thenlt_bare_decomposes(self, hol_session):
         """Standalone >- (top level, not in >> chain) decomposes correctly."""
@@ -361,6 +382,132 @@ class TestThenLTReexpand:
         ends = [s.end for s in result]
         for i in range(1, len(ends)):
             assert ends[i] >= ends[i-1], f"End offsets not monotonic at step {i}: {ends}"
+
+
+# =============================================================================
+# Step Plan: `P` by tac in multi-goal contexts (regression for sg/>- decomp bug)
+#
+# REGRESSION: Previously the step plan decomposed ``P` by tac` into FOUR
+# separate ef() steps: [expand (sg P), open_then1, expand tac, close_paren].
+# When the by-pattern follows a multi-goal-producing tactic (Cases_on, conj_tac,
+# IF_CASES_TAC, etc.) under THEN-distribution (\\ / >>), the decomposition is
+# semantically WRONG:
+#
+#   - `expand (sg P)` distributes per-goal  →  N goals become 2N ([P_i; cont_i])
+#   - `open_then1` focuses ONLY the first global goal           ← bug
+#   - `expand tac` closes only that one P_1
+#   - `close_paren` leaves [cont_1, P_2, cont_2, ..., P_N, cont_N]
+#
+# The N-1 sg-subgoals P_2..P_N are NEVER discharged, so subsequent tactics
+# that operate on the cont_i shape leave the P_i open and the proof appears
+# INCOMPLETE in the MCP — even though Holmake (which runs ``P` by tac` as
+# one atomic per-goal tactic) closes the same proof cleanly.
+#
+# Fix: merge_by_steps in tactic_prefix.sml combines [Subgoal `P`, open_then1,
+# expand+, close_paren] back into a single expand step with the original
+# ``P` by tac` source text. Run via goalFrag.expand, distributes per-goal.
+# =============================================================================
+
+
+class TestByDistribution:
+    """``P` by tac` distribution under THEN over multi-goal stacks."""
+
+    async def test_step_plan_merges_by_after_multi_goal_split(self, hol_session):
+        """The full pattern `Cases_on q \\\\ \\`P\\` by tac \\\\ rest` in step plan
+        keeps the by-pattern as ONE atomic expand (not 4 decomposed steps)."""
+        result = await call_step_plan(
+            hol_session, r"Cases_on `q` >> `P` by tac >> rest"
+        )
+        # Cases_on `q`, `P` by tac, rest
+        kinds = [s.kind for s in result]
+        texts = [s.text for s in result]
+        assert kinds == ["expand", "expand", "expand"], (
+            f"Expected 3 atomic expand steps; got {list(zip(kinds, texts))}"
+        )
+        assert "by" in texts[1] and "`P`" in texts[1], (
+            f"Step 2 should be the merged `P` by tac form; got {texts[1]!r}"
+        )
+        # No bare sg/open_then1/close_paren plumbing should leak through.
+        for s in result:
+            assert s.text not in ("open_then1", "close_paren"), (
+                f"Decomposition plumbing leaked into step plan: {s.text}"
+            )
+            assert not s.text.startswith("sg `"), (
+                f"Raw sg-prefix Subgoal atom should have been merged: {s.text!r}"
+            )
+
+    async def test_by_proof_passes_after_multi_goal_split(self, hol_session):
+        """End-to-end: a proof that uses `P` by tac after a 2-goal split must
+        verify_theorem_json to "all goals closed".
+
+        Without merge_by_steps this exact proof would leave 1 sg-subgoal
+        (`1+1 = 2`) open after the final ACCEPT_TAC TRUTH (which can close
+        T but not 1+1=2). Reflects the data_to_word_assignProofScript.sml
+        cake-while idiom that exposed the bug:
+            Cases_on `q` >> `P` by tac >> closing_tac
+        """
+        await hol_session.send('drop_all();', timeout=5)
+        # Goal: T /\ T  (after conj_tac, 2 identical T goals)
+        cmd = (
+            'verify_theorem_json "T /\\\\ T" "by_multigoal_thm" '
+            '["ef(goalFrag.expand(conj_tac))",'
+            ' "ef(goalFrag.expand(`1+1 = 2` by EVAL_TAC))",'
+            ' "ef(goalFrag.expand(ACCEPT_TAC TRUTH))"] false 10.0;'
+        )
+        result = await hol_session.send(cmd, timeout=30)
+        ok_line = next(
+            (line.strip() for line in result.strip().split('\n')
+             if line.strip().startswith('{"ok":')),
+            None,
+        )
+        assert ok_line is not None, (
+            f"verify_theorem_json did not emit ok JSON. Output: {result!r}"
+        )
+        payload = json.loads(ok_line)['ok']
+        trace = payload.get('trace', [])
+        assert trace, f"Empty trace: {payload!r}"
+        last = trace[-1]
+        assert last.get('goals_after') == 0, (
+            f"Multi-goal `P` by tac left goals open: {trace!r}"
+        )
+
+    async def test_old_decomposition_would_have_failed(self, hol_session):
+        """Negative control: the OLD decomposed sequence
+        [conj_tac, sg `1+1=2`, open_then1, EVAL_TAC, close_paren, ACCEPT_TAC TRUTH]
+        leaves 1 unproven sg-subgoal — confirming that the merge in
+        merge_by_steps is what makes the prior test pass.
+
+        Demonstrates that the decomposition is semantically wrong, not just
+        cosmetically split."""
+        await hol_session.send('drop_all();', timeout=5)
+        cmd = (
+            'verify_theorem_json "T /\\\\ T" "by_multigoal_thm_old" '
+            '["ef(goalFrag.expand(conj_tac))",'
+            ' "ef(goalFrag.expand(sg `1+1 = 2`))",'
+            ' "ef(goalFrag.open_then1)",'
+            ' "ef(goalFrag.expand(EVAL_TAC))",'
+            ' "ef(goalFrag.close_paren)",'
+            ' "ef(goalFrag.expand(ACCEPT_TAC TRUTH))"] false 10.0;'
+        )
+        result = await hol_session.send(cmd, timeout=30)
+        ok_line = next(
+            (line.strip() for line in result.strip().split('\n')
+             if line.strip().startswith('{"ok":')),
+            None,
+        )
+        assert ok_line is not None, (
+            f"verify_theorem_json did not emit ok JSON. Output: {result!r}"
+        )
+        payload = json.loads(ok_line)['ok']
+        trace = payload.get('trace', [])
+        assert trace, f"Empty trace: {payload!r}"
+        last = trace[-1]
+        # The OLD decomposition strands the second `1+1 = 2` sg-subgoal —
+        # confirms why merging is needed.
+        assert last.get('goals_after', 0) > 0 or last.get('err') is not None, (
+            f"Decomposed sequence should have failed/left goals open, "
+            f"but trace says proof closed: {trace!r}"
+        )
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Step plan currently decomposes `` `P` by tac `` into four ef() steps:
`[expand (sg P), open_then1, expand tac, close_paren]`. Under THEN-distribution
(`\\` / `>>`) over a multi-goal stack this is semantically wrong:
`expand (sg P)` distributes per goal (N → 2N), but `open_then1` only focuses
the first global goal, so only `P_1` is discharged. `P_2..P_N` remain as
open subgoals and the proof reports INCOMPLETE — even though Holmake (which
runs `` `P` by tac `` as a single per-goal-atomic tactic) closes the same proof cleanly.

This bites any proof using

```
Cases_on `q` \\ ... \\ `tttt = ttt` by tac \\ rest
```

I hit it on the cake-while branch of CakeML in
`data_to_word_assignProofScript.sml`'s `evaluate_AppendLenLoop_code`, where
`hol_check_proof` reported 7 phantom remaining goals while Holmake built the
same theory without complaint.

## Fix

`merge_by_steps` in `tactic_prefix.sml` post-processes the step list and
collapses `[Subgoal \`P\`, open_then1, expand+, close_paren]` back into a
single atomic step `` `P` by tac `` (or `` `P` by (t1 >> t2) `` for compound
bodies). The merged step runs via `goalFrag.expand` and distributes per-goal
correctly, matching Holmake.

Tactic-base `by` (e.g. `strip_tac by simp[]`) is intentionally left with the
old decomposition: the `Subgoal` atom doesn't get the `sg ` prefix in that
case, the form is rare in practice, and the merge logic gates on the
`sg \`...\`` shape so it doesn't accidentally rewrite tactic-base `by`.

## Test plan

- [x] `TestThenLTReexpand`: updated to assert the merged shape (3 atomic
  steps for `strip_tac >> \`Q\` by simp[] >> fs[]`, etc.).
- [x] `TestByDistribution` (new): three regression tests
  1. Step plan keeps `` `P` by tac `` as one atomic expand after a multi-goal
     `Cases_on`.
  2. End-to-end `verify_theorem_json` on `T /\ T` proven by
     `conj_tac >> \`1+1=2\` by EVAL_TAC >> ACCEPT_TAC TRUTH` now closes
     all goals.
  3. Negative control: the OLD decomposed sequence
     `[conj_tac, sg \`1+1=2\`, open_then1, EVAL_TAC, close_paren,
       ACCEPT_TAC TRUTH]` strands the second `1+1=2` sg-subgoal, confirming
     the bug exists and the merge is what fixes it.
- [x] All 52 tests in `test_tactic_prefix.py`,
  `test_thenlt_decomposition.py`, `test_thenlt_arm_decomposition.py` pass.
- [x] Pre-existing `FunctionTool` failures in `test_mcp_server.py` are
  reproducible on `origin/master` and unrelated.