### PR TITLE
Fix nested >- in >~ select-arm body + preserve `reverse TAC`

### DIFF
--- a/hol4_mcp/sml_helpers/tactic_prefix.sml
+++ b/hol4_mcp/sml_helpers/tactic_prefix.sml
@@ -218,11 +218,19 @@ fun reexpand_group_atoms frags =
     (* Only re-expand Group atoms containing compound expressions (Then, ThenLT, etc.)
        that produce useful navigable sub-steps. Single-step wrappers like Repeat,
        Try, LNullOk etc. should stay atomic — their open/close structure adds
-       navigation overhead without useful intermediate goal states. *)
+       navigation overhead without useful intermediate goal states.
+       ThenLT whose list-tactic argument contains LReverse / LTacsToLT / other
+       structural-only LT-elements MUST stay opaque — re-expanding produces
+       FAtoms (LReverse, etc.) that have no span, get empty text from
+       frag_text, and are silently dropped by assignEnds, which would lose
+       e.g. the `reverse` in `reverse TOP_CASE_TAC`. *)
+    fun ltElemIsStructuralOnly TacticParse.LReverse = true
+      | ltElemIsStructuralOnly _ = false
+    fun lsHasStructuralOnly ls = List.exists ltElemIsStructuralOnly ls
     fun isComposable (TacticParse.Then _) = true
-      | isComposable (TacticParse.ThenLT _) = true
+      | isComposable (TacticParse.ThenLT (_, ls)) = not (lsHasStructuralOnly ls)
       | isComposable (TacticParse.LThen1 _) = true
-      | isComposable (TacticParse.LThenLT _) = true
+      | isComposable (TacticParse.LThenLT ls) = not (lsHasStructuralOnly ls)
       | isComposable (TacticParse.Group _) = true  (* peels outer wrapper; inner expr is checked by recursion *)
       | isComposable _ = false
     fun isGroupAtom (TacticParse.FAtom (TacticParse.Group (_, _, e))) =
@@ -272,29 +280,68 @@ fun merge_select_steps [] acc = rev acc
             | mkSelectPrefix (p :: ps) = "Q.SELECT_GOAL_LT " ^ p ^ " >>~ Q.SELECT_GOALS_LT " ^
                 String.concatWith " >>~ Q.SELECT_GOALS_LT " ps
           val selectPrefix = mkSelectPrefix sels
-          (* Try to consume the following bracket: open (expand)+ close.
-             The body may be a single expand (e.g. >- simp[]) or a compound
-             of expands joined by >> (e.g. >- (simp[] >> fs[])).
-             Bail (NONE) for nested brackets or unexpected fragment kinds —
-             those would need full source reconstruction. *)
+          (* Try to consume the following bracket: open (expand|nested)+ close.
+             The body may be a single expand, a compound of expands joined by
+             >>, or contain NESTED >- / parens. parseBody recursively
+             reconstructs the body text, parenthesising nested >- groups so
+             the precedence ((tac >- body) vs surrounding >>) is preserved.
+             Bails on unsupported open kinds (>|, >~ inside, etc). *)
           fun isOpenArm "open_then1" = true
             | isOpenArm "open_first" = true
             | isOpenArm _ = false
-          fun walkArm [] _ _ = NONE
-            | walkArm ((endP, "close", _) :: rest') texts lastEnd =
-                (case rev texts of
+          (* parseBody: walk steps until matching close at depth 0, returning
+             (combined-text, close-end-offset, remaining-steps). On nested
+             open_then1, the previous atom in acc is wrapped:
+                 last  +  open_then1  +  innerBody  +  close
+                  -> "(" ^ last ^ " >- (" ^ innerBody ^ "))"
+             so subsequent >> joins don't accidentally bind to the THEN1. *)
+          fun parseBody [] _ = NONE  (* unbalanced *)
+            | parseBody ((closeEnd, "close", _) :: rest) acc =
+                (case rev acc of
                    [] => NONE
-                 | [single] => SOME (selectPrefix ^ " >- " ^ single, lastEnd, rest')
-                 | many => SOME (
-                     selectPrefix ^ " >- (" ^
-                     String.concatWith " >> " many ^ ")",
-                     lastEnd, rest'))
-            | walkArm ((endP, "expand", t) :: rest') texts _ =
-                walkArm rest' (t :: texts) endP
-            | walkArm _ _ _ = NONE  (* nested open/mid: bail *)
+                 | xs => SOME (String.concatWith " >> " xs, closeEnd, rest))
+            | parseBody ((_, "open", "open_then1") :: rest) acc =
+                (case parseBody rest [] of
+                   NONE => NONE
+                 | SOME (innerText, _, rest') =>
+                     (case acc of
+                        [] => NONE  (* >- with no preceding atom *)
+                      | last :: restAcc =>
+                          parseBody rest'
+                            (("(" ^ last ^ " >- (" ^ innerText ^ "))") :: restAcc)))
+            | parseBody ((_, "open", "open_paren") :: rest) acc =
+                (case parseBody rest [] of
+                   NONE => NONE
+                 | SOME (innerText, _, rest') =>
+                     parseBody rest' (("(" ^ innerText ^ ")") :: acc))
+            | parseBody ((_, "open", _) :: _) _ = NONE  (* other opens: bail *)
+            | parseBody ((_, "mid", _) :: _) _ = NONE   (* >| / next_select: bail *)
+            | parseBody ((_, "expand", t) :: rest) acc =
+                parseBody rest (t :: acc)
+            | parseBody ((_, "expand_list", t) :: rest) acc =
+                parseBody rest (("(" ^ t ^ ")") :: acc)
+            | parseBody _ _ = NONE
+          (* Wrap final body for the >- arm of the SELECT_GOAL_LT.
+             Single-token body: no extra parens (matches old behaviour).
+             Multi-token body: parenthesise so >- binds the whole chain. *)
+          fun finishArm bodyText closeEnd rest' =
+                let
+                  (* Detect "single token" by absence of a top-level >> *)
+                  val needsParens = String.isSubstring " >> " bodyText
+                  val wrapped = if needsParens
+                                then "(" ^ bodyText ^ ")"
+                                else bodyText
+                in
+                  SOME (selectPrefix ^ " >- " ^ wrapped, closeEnd, rest')
+                end
           fun tryConsumeBracket [] = NONE
             | tryConsumeBracket ((_, "open", openName) :: rest') =
-                if isOpenArm openName then walkArm rest' [] 0 else NONE
+                if isOpenArm openName then
+                  (case parseBody rest' [] of
+                     NONE => NONE
+                   | SOME (bodyText, closeEnd, rest'') =>
+                       finishArm bodyText closeEnd rest'')
+                else NONE
             | tryConsumeBracket _ = NONE
         in
           case tryConsumeBracket afterSels of

--- a/tests/test_tactic_prefix.py
+++ b/tests/test_tactic_prefix.py
@@ -511,6 +511,145 @@ class TestByDistribution:
 
 
 # =============================================================================
+# Step Plan: >~ [pat] >- (compound body with NESTED >-)
+#
+# REGRESSION: Previously merge_select_steps' walkArm bailed on ANY nested
+# open inside the body of >~ [pat] >- (...), and the "no bracket consumed"
+# branch then silently DROPPED the SELECT step. Result: `>~ [pat]` never
+# executed, the following `>-` focused the wrong goal, and the proof
+# silently mis-executed (or failed many steps later for unrelated-looking
+# reasons). Hit on the cake-while branch when inlining a Resume[Result]
+# body that contained `\\ reverse TOP_CASE_TAC >- (rw [] \\ rw [])`.
+#
+# Fix: parseBody walks nested brackets recursively, parenthesising nested
+# `>-` groups so SML precedence (>- inside >> chain) is preserved.
+# =============================================================================
+
+
+class TestSelectGoalNestedBody:
+    """`>~ [pat] >- (body with nested >-)` must merge into a single
+    expand_list step, not silently drop the SELECT pattern."""
+
+    async def test_nested_then1_inside_select_body_merges(self, hol_session):
+        """Body of `>~ [pat] >- (... >- ...)` is reconstructed with nested
+        >- properly parenthesised so the SELECT_GOAL_LT prefix survives."""
+        result = await call_step_plan(
+            hol_session,
+            "Cases_on `x` >~ [`Foo`] >- (a >> b >- c >> d)"
+        )
+        assert len(result) == 2, (
+            f"Expected 2 steps (Cases_on, expand_list); got "
+            f"{[(s.kind, s.text) for s in result]}"
+        )
+        assert result[0].kind == "expand"
+        assert result[1].kind == "expand_list", (
+            f"Compound body with nested >- must yield expand_list, "
+            f"not bare expand or dropped select: {result[1].kind}"
+        )
+        text = result[1].text
+        assert "Q.SELECT_GOAL_LT" in text, (
+            f"SELECT_GOAL_LT prefix dropped: {text!r}"
+        )
+        for tok in ("`Foo`", "a", "b", "c", "d"):
+            assert tok in text, (
+                f"Token {tok!r} missing from reconstruction: {text!r}"
+            )
+
+    async def test_double_nested_then1_inside_select_body(self, hol_session):
+        """Two nested >- arms in body still merge correctly."""
+        result = await call_step_plan(
+            hol_session,
+            "Cases_on `x` >~ [`Foo`] >- (a >- b >- c)"
+        )
+        assert len(result) == 2
+        assert result[1].kind == "expand_list"
+        text = result[1].text
+        assert "Q.SELECT_GOAL_LT" in text
+        for tok in ("`Foo`", "a", "b", "c"):
+            assert tok in text, f"Token {tok!r} missing from {text!r}"
+
+    async def test_nested_paren_inside_select_body(self, hol_session):
+        """Plain (...) nesting inside select body merges correctly."""
+        result = await call_step_plan(
+            hol_session,
+            "Cases_on `x` >~ [`Foo`] >- (a >> (b >> c) >> d)"
+        )
+        assert len(result) == 2
+        assert result[1].kind == "expand_list"
+        for tok in ("`Foo`", "a", "b", "c", "d"):
+            assert tok in result[1].text
+
+    async def test_select_no_nested_unchanged(self, hol_session):
+        """Existing flat-body case still merges as before (regression guard)."""
+        result = await call_step_plan(
+            hol_session,
+            "Cases_on `x` >~ [`Foo`] >- simp[]"
+        )
+        assert len(result) == 2
+        assert result[1].kind == "expand_list"
+        assert "Q.SELECT_GOAL_LT" in result[1].text
+        assert "simp[]" in result[1].text
+
+
+# =============================================================================
+# Step Plan: `reverse TAC` is preserved (not stripped to bare TAC)
+#
+# REGRESSION: TacticParse parses `reverse TAC` as
+#   Group(span, ThenLT(TAC, [LReverse]))
+# reexpand_group_atoms previously re-expanded ANY ThenLT-containing Group,
+# producing flat frags [FAtom TAC, FAtom LReverse]. LReverse has no span,
+# so frag_text returned "" and assignEnds dropped it — losing the `reverse`
+# wrapper entirely. The decomposed step ran TAC alone, which has the wrong
+# goal-stack ordering vs `reverse TAC`.
+#
+# Fix: lsHasStructuralOnly excludes ThenLTs whose list-tactic part has
+# LReverse (or other span-less LT-elements) from re-expansion. The Group
+# stays as a single FAtom whose text is the full `reverse TAC` source.
+# =============================================================================
+
+
+class TestReverseTactical:
+    """`reverse TAC` must survive linearization as a single atomic step."""
+
+    async def test_reverse_preserved_in_step_text(self, hol_session):
+        """Step plan for `reverse TOP_CASE_TAC` keeps the `reverse` prefix."""
+        result = await call_step_plan(hol_session, "reverse TOP_CASE_TAC")
+        assert len(result) == 1, (
+            f"Expected one atomic step for `reverse TOP_CASE_TAC`; got "
+            f"{[(s.kind, s.text) for s in result]}"
+        )
+        assert result[0].kind == "expand"
+        assert result[0].text == "reverse TOP_CASE_TAC", (
+            f"`reverse` prefix dropped: {result[0].text!r}"
+        )
+
+    async def test_reverse_in_then_chain_keeps_prefix(self, hol_session):
+        """`reverse TOP_CASE_TAC` inside a >> chain still keeps `reverse`."""
+        result = await call_step_plan(
+            hol_session, "strip_tac >> reverse TOP_CASE_TAC >> simp[]"
+        )
+        assert len(result) == 3
+        assert result[1].text == "reverse TOP_CASE_TAC", (
+            f"`reverse` prefix dropped in chain: {result[1].text!r}"
+        )
+
+    async def test_reverse_with_then1_arm(self, hol_session):
+        """`reverse TAC >- arm` keeps `reverse` and decomposes the >-."""
+        result = await call_step_plan(
+            hol_session, "reverse TOP_CASE_TAC >- simp[]"
+        )
+        # Expect: expand "reverse TOP_CASE_TAC", open_then1, expand simp[], close_paren
+        assert len(result) == 4, (
+            f"Expected 4 steps; got {[(s.kind, s.text) for s in result]}"
+        )
+        assert result[0].kind == "expand"
+        assert result[0].text == "reverse TOP_CASE_TAC"
+        assert result[1].kind == "open"
+        assert result[2].text == "simp[]"
+        assert result[3].kind == "close"
+
+
+# =============================================================================
 # Step Plan: >~ (SELECT_GOAL_LT) decomposition
 # =============================================================================
 
@@ -734,3 +873,49 @@ class TestResumeGoalExtraction:
         assert trace[-1].get('goals_after') == 0, (
             f"Resume tactics did not close goal: {trace!r}"
         )
+    async def test_select_goal_compound_body_then(self, hol_session):
+        """>~[pat] >- (a >> b): compound body must be merged, not silently dropped.
+
+        Regression: previously the SELECT_GOAL_LT prefix was dropped when the
+        `>-` body had multiple tactics joined by `>>` (the bracket pattern
+        match in tryConsumeBracket was open+single_expand+close). With the
+        prefix dropped, the `>~` selector never executed and `>-` ran on the
+        un-reordered goal stack, picking the wrong goal."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (simp[] >> fs[])")
+        # Must produce: expand(Cases_on), expand_list(Q.SELECT_GOAL_LT [`Foo`] >- (simp[] >> fs[]))
+        assert len(result) == 2, f"Expected 2 steps, got {len(result)}: {[(s.kind, s.text) for s in result]}"
+        assert result[0].kind == "expand"
+        assert result[1].kind == "expand_list", \
+            f"Compound body should yield expand_list step, got kind={result[1].kind} text={result[1].text!r}"
+        assert "Q.SELECT_GOAL_LT" in result[1].text
+        assert "`Foo`" in result[1].text
+        assert "simp[]" in result[1].text
+        assert "fs[]" in result[1].text
+
+    async def test_select_goal_compound_body_three_then(self, hol_session):
+        """>~[pat] >- (a >> b >> c): three-tactic compound body."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (a >> b >> c)")
+        assert len(result) == 2
+        assert result[1].kind == "expand_list"
+        assert "Q.SELECT_GOAL_LT" in result[1].text
+        # All three sub-tactics must be present
+        for tac in ("a", "b", "c"):
+            assert tac in result[1].text
+
+    async def test_select_goal_compound_body_associativity(self, hol_session):
+        """Compound body must parenthesize so `>-` doesn't bind only to first sub-tactic.
+
+        `Q.SELECT_GOAL_LT [pat] >- a >> b` parses as
+          `(Q.SELECT_GOAL_LT [pat] >- a) >> b`
+        which would run `b` on goals OUTSIDE the >- arm. The body must be
+        wrapped in parens so the entire compound is the arm body."""
+        result = await call_step_plan(hol_session, "Cases_on `x` >~ [`Foo`] >- (simp[] >> fs[])")
+        # The combined text must keep simp[] >> fs[] grouped (parens, or some
+        # equivalent that prevents `>-` from binding only to simp[]).
+        text = result[1].text
+        # Find the position of `>-` and check what follows is parenthesized
+        dash_idx = text.find(">-")
+        assert dash_idx >= 0
+        body = text[dash_idx + 2:].lstrip()
+        assert body.startswith("("), \
+            f"Compound body must be parenthesized; got {body!r}"


### PR DESCRIPTION
Two follow-on step-plan fixes that surfaced while exercising PR #20's
`P` by tac decomposition fix on real cake-while proofs. Both are
correctness bugs, not navigation issues — they cause the MCP step plan
to silently mis-execute or drop tactics for common HOL4 patterns.

## 1. Nested `>-` in `>~ [pat] >- (...)` body

**Bug:** `merge_select_steps`' inner `walkArm` bailed (`NONE`) on ANY
nested open inside the body of a select arm. The "no bracket consumed"
branch then silently DROPPED the SELECT step, so `>~ [pat]` never
executed. The following `>-` then focused the un-reordered first goal
— wrong arm executed, often failing many steps later for
unrelated-looking reasons.

**Trigger:** `>~ [\`Foo\`] >- (... \\ reverse TOP_CASE_TAC >- (rw [] \\ rw []))`
or any compound select-arm body containing nested `>-` / `(...)` / etc.

**Fix:** Replace `walkArm` with recursive `parseBody` that walks nested
brackets at depth, parenthesising nested `>-` groups so SML precedence
(`>-` inside `>>` chain) is preserved. Bails only on truly unsupported
open kinds (`>|`, `>~` inside).

Tests: `TestSelectGoalNestedBody` (4 cases) + 3 misplaced cases
appended to `TestResumeGoalExtraction`.

## 2. `reverse TAC` stripped to bare `TAC`

**Bug:** TacticParse parses `reverse TAC` as
`Group(span, ThenLT(TAC, [LReverse]))`. `reexpand_group_atoms`
re-expanded ANY ThenLT-containing Group, producing flat fragments
`[FAtom TAC, FAtom LReverse]`. `LReverse` has no span, so `frag_text`
returned `""` and `assignEnds` dropped it — losing the `reverse`
wrapper entirely. The decomposed step ran bare `TAC` against the
un-reversed goal stack — different proof semantics.

**Fix:** `lsHasStructuralOnly` excludes ThenLTs whose list-tactic part
has `LReverse` (or other span-less LT-elements) from re-expansion.
The Group stays as a single FAtom whose text is the full `reverse TAC`
source.

Tests: `TestReverseTactical` (3 cases).

## Test status

All 51 tests in `tests/test_tactic_prefix.py` pass.

Pre-existing `FunctionTool object is not callable` failures elsewhere
in the suite are reproducible on `origin/master` and unrelated
(fastmcp 3.x compat issue with intra-module tool calls).

## Background

These two fixes were originally intended for #20 but only the by-fix
commit landed there. Submitting now standalone — both are
correctness-affecting bugs that real users will hit, and they're
independent of any further open work on `>-` distribution.